### PR TITLE
Create directory before copy file in taskCopyVersionForWrapper

### DIFF
--- a/kobalt/src/Build.kt
+++ b/kobalt/src/Build.kt
@@ -131,6 +131,7 @@ fun readVersion() : String {
 @com.beust.kobalt.api.annotation.Task(name = "copyVersionForWrapper", runBefore = arrayOf("compile"), description = "")
 fun taskCopyVersionForWrapper(project: Project) : TaskResult {
     if (project.name == "kobalt-wrapper") {
+        Files.createDirectories(Paths.get("modules/wrapper/kobaltBuild/classes"))
         Files.copy(Paths.get("src/main/resources/kobalt.properties"),
                 Paths.get("modules/wrapper/kobaltBuild/classes/kobalt.properties"),
                 StandardCopyOption.REPLACE_EXISTING)


### PR DESCRIPTION
Currently `./kobaltw test` fails to compile tests on clean cloned repo due to missing directory. It causes testng to run no tests and kobalt reports success that is not correct. 