### PR TITLE
fix xml parsing problem with stax-api pom

### DIFF
--- a/src/main/kotlin/com/beust/kobalt/maven/Pom.kt
+++ b/src/main/kotlin/com/beust/kobalt/maven/Pom.kt
@@ -59,7 +59,7 @@ public class Pom @javax.inject.Inject constructor(@Assisted val id: String,
     init {
         val DEPENDENCIES = XPATH.compile("/project/dependencies/dependency")
 
-        val document = kotlinx.dom.parseXml(InputSource(FileReader(documentFile)))
+        val document = kotlinx.dom.parseXml(InputSource(FileInputStream(documentFile)))
         groupId = XPATH.compile("/project/groupId").evaluate(document)
         artifactId = XPATH.compile("/project/artifactId").evaluate(document)
         version = XPATH.compile("/project/version").evaluate(document)


### PR DESCRIPTION
I got the error below.  And found the fix here: http://stackoverflow.com/questions/5138696/org-xml-sax-saxparseexception-content-is-not-allowed-in-prolog


[Fatal Error] :8:1: Content is not allowed in trailing section.
***** WARNING Exception when trying to resolve dependencies for javax.xml.stream:stax-api:1.0-2: Unable to provision, see the following errors:

1) Error injecting constructor, org.xml.sax.SAXParseException; lineNumber: 8; columnNumber: 1; Content is not allowed in trailing section.
  at com.beust.kobalt.maven.Pom.<init>(Pom.kt:13)
  while locating com.beust.kobalt.maven.Pom annotated with @com.google.inject.internal.UniqueAnnotations$Internal(value=1)