### PR TITLE
Make kobaltw play nice when it's soft-linked (`ln -s`)

### DIFF
--- a/kobaltw
+++ b/kobaltw
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-java -jar $(dirname $0)/kobalt/wrapper/kobalt-wrapper.jar $*
+java -jar $(dirname "$(readlink -f $0)")/kobalt/wrapper/kobalt-wrapper.jar $*

--- a/modules/wrapper/src/main/java/com/beust/kobalt/wrapper/Main.java
+++ b/modules/wrapper/src/main/java/com/beust/kobalt/wrapper/Main.java
@@ -206,7 +206,7 @@ public class Main {
         }
         log(2, "Generating " + KOBALTW + (envFile.exists() ? " with shebang" : "") + ".");
 
-        content += "java -jar $(dirname $0)/kobalt/wrapper/kobalt-wrapper.jar $*\n";
+        content += "java -jar $(dirname \"$(readlink -f $0)\")/kobalt/wrapper/kobalt-wrapper.jar $*\n";
 
         Files.write(filePath, content.getBytes());
 


### PR DESCRIPTION
1. On linux 3rd party (non-repo) programs go to `/usr/local/`, their executables go (or are linked) to `/usr/local/bin/` I prefer linking, as it is much more maintainable.
2. `kobaltw` is too cumbersome to type, so it's `kw` for me. :)