### PR TITLE
Support for bintray Organizations

### DIFF
--- a/src/main/kotlin/com/beust/kobalt/plugin/publish/JCenterApi.kt
+++ b/src/main/kotlin/com/beust/kobalt/plugin/publish/JCenterApi.kt
@@ -53,16 +53,17 @@ open public class UnauthenticatedJCenterApi @Inject constructor(open val http: H
 }
 
 public class JCenterApi @Inject constructor (@Nullable @Assisted("username") val username: String?,
-        @Nullable @Assisted("password") val password: String?,
+        @Nullable @Assisted("password") val password: String?, @Nullable @Assisted("org") val org: String?,
         override val http: Http, val gpg: Gpg, val executors: KobaltExecutors) : UnauthenticatedJCenterApi(http) {
 
     interface IFactory {
         fun create(@Nullable @Assisted("username") username: String?,
-                @Nullable @Assisted("password") password: String?) : JCenterApi
+                   @Nullable @Assisted("password") password: String?,
+                   @Nullable @Assisted("org") org: String?) : JCenterApi
     }
 
     fun packageExists(packageName: String) : Boolean {
-        val url = arrayListOf(UnauthenticatedJCenterApi.BINTRAY_URL_API, "packages", username!!, "maven", packageName)
+        val url = arrayListOf(UnauthenticatedJCenterApi.BINTRAY_URL_API, "packages", org ?: username!!, "maven", packageName)
                 .joinToString("/")
         val jcResponse = parseResponse(http.get(username, password, url))
 
@@ -90,7 +91,7 @@ public class JCenterApi @Inject constructor (@Nullable @Assisted("username") val
         val fileToPath: (File) -> String = { f: File ->
             arrayListOf(
                     UnauthenticatedJCenterApi.BINTRAY_URL_API_CONTENT,
-                    username!!,
+                    org ?: username!!,
                     "maven",
                     project.name,
                     project.version!!,
@@ -107,7 +108,7 @@ public class JCenterApi @Inject constructor (@Nullable @Assisted("username") val
     fun uploadFile(file: File, url: String, config: JCenterConfig, generateMd5: Boolean = false,
             generateAsc: Boolean = false) =
         upload(arrayListOf(file), config, {
-                f: File -> "${UnauthenticatedJCenterApi.BINTRAY_URL_API_CONTENT}/$username/generic/$url"},
+                f: File -> "${UnauthenticatedJCenterApi.BINTRAY_URL_API_CONTENT}/${org ?: username}/generic/$url"},
                 generateMd5, generateAsc)
 
     private fun upload(files: List<File>, config: JCenterConfig?, fileToPath: (File) -> String,

--- a/src/main/kotlin/com/beust/kobalt/plugin/publish/PublishPlugin.kt
+++ b/src/main/kotlin/com/beust/kobalt/plugin/publish/PublishPlugin.kt
@@ -29,6 +29,7 @@ public class PublishPlugin @Inject constructor(val files: KFiles, val factory: P
 
         private const val PROPERTY_BINTRAY_USER = "bintray.user"
         private const val PROPERTY_BINTRAY_PASSWORD = "bintray.apikey"
+        private const val PROPERTY_BINTRAY_ORG = "bintray.organization"
     }
 
     @Suppress("UNUSED_FUNCTION_LITERAL")
@@ -90,8 +91,9 @@ public class PublishPlugin @Inject constructor(val files: KFiles, val factory: P
         val docUrl = DocUrl.PUBLISH_PLUGIN_URL
         val user = localProperties.get(PROPERTY_BINTRAY_USER, docUrl)
         val password = localProperties.get(PROPERTY_BINTRAY_PASSWORD, docUrl)
+        val org = localProperties.get(PROPERTY_BINTRAY_ORG, docUrl)
 
-        val jcenter = jcenterFactory.create(user, password)
+        val jcenter = jcenterFactory.create(user, password, org)
         var success = false
         val configuration = jcenterConfigurations[project.name]
         val messages = arrayListOf<String>()


### PR DESCRIPTION
This patch adds an optional `bintray.organization` to local.properties. 
```
bintray.user=asarazan
bintray.organization=levelmoney
bintray.apikey=...
```
