### PR TITLE
Introduce test directives for including and excluding files

### DIFF
--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/BuildScript.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/BuildScript.kt
@@ -6,6 +6,10 @@ import com.beust.kobalt.api.annotation.Directive
 import com.beust.kobalt.maven.DepFactory
 import com.beust.kobalt.maven.dependency.FileDependency
 import java.io.File
+import kotlin.collections.forEach
+import kotlin.collections.joinToString
+import kotlin.collections.toArrayList
+import kotlin.text.isNullOrBlank
 
 @Directive
 fun homeDir(vararg dirs: String) : String = SystemProperties.homeDir +

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/FileSpec.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/FileSpec.kt
@@ -3,36 +3,96 @@ package com.beust.kobalt
 import com.beust.kobalt.misc.log
 import java.io.File
 import java.nio.file.*
+import java.nio.file.FileVisitResult.CONTINUE
 import java.nio.file.attribute.BasicFileAttributes
+import java.util.*
+import kotlin.collections.*
 
 sealed class IFileSpec {
     abstract fun toFiles(directory: String): List<File>
+    abstract fun toFile(file: String): List<File>
 
     class FileSpec(val spec: String) : IFileSpec() {
         override public fun toFiles(directory: String) = listOf(File(spec))
+        override public fun toFile(file: String) = listOf(File(spec))
 
         override public fun toString() = spec
     }
 
-    class GlobSpec(val spec: String) : IFileSpec() {
-        override public fun toFiles(directory: String): List<File> {
-            val result = arrayListOf<File>()
+    class GlobSpec(val includeSpec: ArrayList<String>, val excludeSpec: ArrayList<String>) : IFileSpec() {
 
-            val matcher = FileSystems.getDefault().getPathMatcher("glob:$spec")
+        constructor(spec: String) : this(arrayListOf(spec), arrayListOf())
+
+        override public fun toFiles(directory: String): List<File> {
+
+            val result = arrayListOf<File>()
+            val includeMatchers = prepareMatchers(includeSpec.toTypedArray())
+            val excludeMatchers = prepareMatchers(excludeSpec.toTypedArray())
+
             Files.walkFileTree(Paths.get(directory), object : SimpleFileVisitor<Path>() {
                 override public fun visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult {
+
                     val rel = Paths.get(directory).relativize(path)
-                    if (matcher.matches(rel)) {
-                        log(3, "Adding ${rel.toFile()}")
-                        result.add(rel.toFile())
+                    excludeMatchers.forEach {
+                        if (it.matches(rel)) {
+                            log(3, "Removing ${rel.toFile()}")
+                            return CONTINUE
+                        }
                     }
-                    return FileVisitResult.CONTINUE
+                    includeMatchers.forEach {
+                        if (it.matches(rel)) {
+                            log(3, "Adding ${rel.toFile()}")
+                            result.add(rel.toFile())
+                            return CONTINUE
+                        }
+                    }
+
+                    return CONTINUE
                 }
             })
             return result
         }
 
-        override public fun toString() = spec
+        override public fun toFile(file: String): List<File> {
+
+            val result = arrayListOf<File>()
+            val includeMatchers = prepareMatchers(includeSpec.toTypedArray())
+            val excludeMatchers = prepareMatchers(excludeSpec.toTypedArray())
+
+            val rel = Paths.get(file)
+            excludeMatchers.forEach {
+                if (it.matches(rel)) {
+                    log(3, "Removing ${rel.toFile()}")
+                    return result
+                }
+            }
+            includeMatchers.forEach {
+                if (it.matches(rel)) {
+                    log(3, "Adding ${rel.toFile()}")
+                    result.add(rel.toFile())
+                    return result
+                }
+            }
+            return result
+        }
+
+        override public fun toString(): String {
+            var result = ""
+            includeSpec.apply {
+                if (!isEmpty()) {
+                    result += "Included files: " + joinToString { ", " }
+                }
+            }
+            excludeSpec.apply {
+                if (!isEmpty()) {
+                    result += "Excluded files: " + joinToString { ", " }
+                }
+            }
+            return result
+        }
+
+        private fun prepareMatchers(specs: Array<String>): List<PathMatcher> =
+                specs.map { it -> FileSystems.getDefault().getPathMatcher("glob:$it") }
     }
 
 }

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/Plugins.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/Plugins.kt
@@ -18,6 +18,7 @@ import java.util.*
 import java.util.jar.JarFile
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.collections.*
 
 @Singleton
 public class Plugins @Inject constructor (val taskManagerProvider : Provider<TaskManager>,

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/TestDirective.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/TestDirective.kt
@@ -2,6 +2,8 @@ package com.beust.kobalt
 
 import com.beust.kobalt.api.Project
 import com.beust.kobalt.api.annotation.Directive
+import kotlin.collections.map
+import kotlin.text.endsWith
 
 class TestConfig(val project: Project) {
     fun args(vararg arg: String) {
@@ -10,6 +12,17 @@ class TestConfig(val project: Project) {
 
     fun jvmArgs(vararg arg: String) {
         project.testJvmArgs.addAll(arg)
+    }
+
+    fun includes(vararg arg: String) {
+        project.testIncludes.apply {
+            clear()
+            addAll(arg)
+        }
+    }
+
+    fun excludes(vararg arg: String) {
+        project.testExcludes.addAll(arg)
     }
 }
 

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/api/BasePlugin.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/api/BasePlugin.kt
@@ -2,6 +2,8 @@ package com.beust.kobalt.api
 
 import com.beust.kobalt.Plugins
 import com.beust.kobalt.internal.TaskManager
+import kotlin.collections.arrayListOf
+import kotlin.collections.toList
 
 abstract public class BasePlugin : IPlugin {
     lateinit var context: KobaltContext

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/api/Project.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/api/Project.kt
@@ -5,6 +5,10 @@ import com.beust.kobalt.internal.IProjectInfo
 import com.beust.kobalt.maven.dependency.MavenDependency
 import com.beust.kobalt.misc.KFiles
 import java.util.*
+import kotlin.collections.arrayListOf
+import kotlin.collections.forEach
+import kotlin.collections.hashMapOf
+import kotlin.collections.hashSetOf
 
 open class Project(
         @Directive open var name: String,
@@ -15,18 +19,20 @@ open class Project(
         @Directive open var artifactId: String? = null,
         @Directive open var packaging: String? = null,
         @Directive open var dependencies: Dependencies? = null,
-        @Directive open var sourceSuffix : String = "",
-        @Directive open var description : String = "",
-        @Directive open var scm : Scm? = null,
+        @Directive open var sourceSuffix: String = "",
+        @Directive open var description: String = "",
+        @Directive open var scm: Scm? = null,
         @Directive open var url: String? = null,
         @Directive open var licenses: List<License> = arrayListOf<License>(),
         @Directive open var packageName: String? = group,
         val projectInfo: IProjectInfo) : IBuildConfig {
 
-    override var buildConfig : BuildConfig? = null //BuildConfig()
+    override var buildConfig: BuildConfig? = null //BuildConfig()
 
     val testArgs = arrayListOf<String>()
     val testJvmArgs = arrayListOf<String>()
+    val testIncludes = arrayListOf("**/*Test.class")
+    val testExcludes = arrayListOf<String>()
 
     val projectProperties = ProjectProperties()
 
@@ -43,28 +49,28 @@ open class Project(
     //
 
     @Directive
-    fun sourceDirectories(init: Sources.() -> Unit) : Sources {
+    fun sourceDirectories(init: Sources.() -> Unit): Sources {
         val sources = Sources(this, sourceDirectories)
         sources.init()
         return sources
     }
 
-    var sourceDirectories : HashSet<String> = hashSetOf()
+    var sourceDirectories: HashSet<String> = hashSetOf()
         get() = if (field.isEmpty()) projectInfo.defaultSourceDirectories else field
         set(value) {
             field = value
         }
 
     @Directive
-    fun sourceDirectoriesTest(init: Sources.() -> Unit) : Sources {
+    fun sourceDirectoriesTest(init: Sources.() -> Unit): Sources {
         val sources = Sources(this, sourceDirectoriesTest)
         sources.init()
         return sources
     }
 
-    var sourceDirectoriesTest : HashSet<String> = hashSetOf()
+    var sourceDirectoriesTest: HashSet<String> = hashSetOf()
         get() = if (field.isEmpty()) projectInfo.defaultTestDirectories
-                else field
+        else field
         set(value) {
             field = value
         }
@@ -74,25 +80,25 @@ open class Project(
     //
 
     @Directive
-    fun dependencies(init: Dependencies.() -> Unit) : Dependencies {
+    fun dependencies(init: Dependencies.() -> Unit): Dependencies {
         dependencies = Dependencies(this, compileDependencies, compileProvidedDependencies, compileRuntimeDependencies)
         dependencies!!.init()
         return dependencies!!
     }
 
-    val compileDependencies : ArrayList<IClasspathDependency> = arrayListOf()
-    val compileProvidedDependencies : ArrayList<IClasspathDependency> = arrayListOf()
-    val compileRuntimeDependencies : ArrayList<IClasspathDependency> = arrayListOf()
+    val compileDependencies: ArrayList<IClasspathDependency> = arrayListOf()
+    val compileProvidedDependencies: ArrayList<IClasspathDependency> = arrayListOf()
+    val compileRuntimeDependencies: ArrayList<IClasspathDependency> = arrayListOf()
 
     @Directive
-    fun dependenciesTest(init: Dependencies.() -> Unit) : Dependencies {
+    fun dependenciesTest(init: Dependencies.() -> Unit): Dependencies {
         dependencies = Dependencies(this, testDependencies, testProvidedDependencies, compileRuntimeDependencies)
         dependencies!!.init()
         return dependencies!!
     }
 
-    val testDependencies : ArrayList<IClasspathDependency> = arrayListOf()
-    val testProvidedDependencies : ArrayList<IClasspathDependency> = arrayListOf()
+    val testDependencies: ArrayList<IClasspathDependency> = arrayListOf()
+    val testProvidedDependencies: ArrayList<IClasspathDependency> = arrayListOf()
 
     /** Used to disambiguate various name properties */
     @Directive
@@ -127,8 +133,8 @@ class Sources(val project: Project, val sources: HashSet<String>) {
 }
 
 class Dependencies(val project: Project, val dependencies: ArrayList<IClasspathDependency>,
-        val providedDependencies: ArrayList<IClasspathDependency>,
-        val runtimeDependencies: ArrayList<IClasspathDependency>) {
+                   val providedDependencies: ArrayList<IClasspathDependency>,
+                   val runtimeDependencies: ArrayList<IClasspathDependency>) {
     @Directive
     fun compile(vararg dep: String) {
         dep.forEach { dependencies.add(MavenDependency.create(it)) }
@@ -136,19 +142,19 @@ class Dependencies(val project: Project, val dependencies: ArrayList<IClasspathD
 
     @Directive
     fun provided(vararg dep: String) {
-        dep.forEach { providedDependencies.add(MavenDependency.create(it))}
+        dep.forEach { providedDependencies.add(MavenDependency.create(it)) }
     }
 
     @Directive
     fun runtime(vararg dep: String) {
-        dep.forEach { runtimeDependencies.add(MavenDependency.create(it))}
+        dep.forEach { runtimeDependencies.add(MavenDependency.create(it)) }
     }
 }
 
 class Scm(val connection: String, val developerConnection: String, val url: String)
 
 class License(val name: String, val url: String) {
-    fun toMavenLicense() : org.apache.maven.model.License {
+    fun toMavenLicense(): org.apache.maven.model.License {
         val result = org.apache.maven.model.License()
         result.name = name
         result.url = url
@@ -179,30 +185,30 @@ interface IBuildConfig {
 
 class ProductFlavorConfig(val name: String) : IBuildConfig {
     var applicationId: String? = null
-    override var buildConfig : BuildConfig? = BuildConfig()
+    override var buildConfig: BuildConfig? = BuildConfig()
 }
 
 @Directive
 fun Project.productFlavor(name: String, init: ProductFlavorConfig.() -> Unit) = ProductFlavorConfig(name).apply {
-        init()
-        addProductFlavor(name, this)
-    }
+    init()
+    addProductFlavor(name, this)
+}
 
 class BuildTypeConfig(val project: Project?, val name: String) : IBuildConfig {
     var minifyEnabled = false
     var applicationIdSuffix: String? = null
     var proguardFile: String? = null
 
-//    fun getDefaultProguardFile(name: String) : String {
-//        val androidPlugin = Plugins.findPlugin(AndroidPlugin.PLUGIN_NAME) as AndroidPlugin
-//        return Proguard(androidPlugin.androidHome(project)).getDefaultProguardFile(name)
-//    }
+    //    fun getDefaultProguardFile(name: String) : String {
+    //        val androidPlugin = Plugins.findPlugin(AndroidPlugin.PLUGIN_NAME) as AndroidPlugin
+    //        return Proguard(androidPlugin.androidHome(project)).getDefaultProguardFile(name)
+    //    }
 
-    override var buildConfig : BuildConfig? = BuildConfig()
+    override var buildConfig: BuildConfig? = BuildConfig()
 }
 
 @Directive
 fun Project.buildType(name: String, init: BuildTypeConfig.() -> Unit) = BuildTypeConfig(this, name).apply {
-        init()
-        addBuildType(name, this)
-    }
+    init()
+    addBuildType(name, this)
+}

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/JUnitRunner.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/JUnitRunner.kt
@@ -9,15 +9,6 @@ open public class JUnitRunner() : GenericTestRunner() {
 
     override val dependencyName = "junit"
 
-    override fun args(project: Project, classpath: List<IClasspathDependency>)
-            = findTestClasses(project, classpath) {
-        // Only return a class if it contains at least one @Test method, otherwise
-        // JUnit 4 throws an exception :-(
-        it.declaredMethods.flatMap {
-            it.annotations.toList()
-        }.filter {
-            ann: Annotation -> ann.javaClass.name.contains("Test")
-        }.size > 0
-    }
+    override fun args(project: Project, classpath: List<IClasspathDependency>) = findTestClasses(project, classpath)
 }
 

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/KobaltPluginXml.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/KobaltPluginXml.kt
@@ -8,6 +8,9 @@ import java.io.InputStream
 import javax.xml.bind.JAXBContext
 import javax.xml.bind.annotation.XmlElement
 import javax.xml.bind.annotation.XmlRootElement
+import kotlin.collections.arrayListOf
+import kotlin.collections.forEach
+import kotlin.text.toByteArray
 
 //
 // Operations related to the parsing of kobalt-plugin.xml: XML parsing, PluginInfo, etc...

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/TaskManager.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/TaskManager.kt
@@ -16,6 +16,9 @@ import java.lang.reflect.Method
 import java.util.*
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.collections.arrayListOf
+import kotlin.collections.filter
+import kotlin.collections.forEach
 
 @Singleton
 public class TaskManager @Inject constructor(val args: Args, val incrementalManager: IncrementalManager) {

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/JarUtils.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/JarUtils.kt
@@ -1,6 +1,7 @@
 package com.beust.kobalt.misc
 
 import com.beust.kobalt.IFileSpec
+import com.beust.kobalt.IFileSpec.GlobSpec
 import com.google.common.io.CharStreams
 import java.io.*
 import java.util.jar.JarEntry
@@ -10,6 +11,14 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipException
 import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
+import kotlin.collections.arrayListOf
+import kotlin.collections.forEach
+import kotlin.collections.listOf
+import kotlin.collections.map
+import kotlin.text.contains
+import kotlin.text.endsWith
+import kotlin.text.isEmpty
+import kotlin.text.replace
 
 public class JarUtils {
     companion object {
@@ -28,10 +37,8 @@ public class JarUtils {
             }
         }
 
-        private val DEFAULT_JAR_EXCLUDES = arrayListOf(
-                IFileSpec.GlobSpec("META-INF/*.SF"),
-                IFileSpec.GlobSpec("META-INF/*.DSA"),
-                IFileSpec.GlobSpec("META-INF/*.RSA"))
+        private val DEFAULT_JAR_EXCLUDES =
+                GlobSpec(arrayListOf(), arrayListOf("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA"))
 
         public fun addSingleFile(directory: String, file: IncludedFile, outputStream: ZipOutputStream,
                 expandJarFiles: Boolean, onError: (Exception) -> Unit = DEFAULT_HANDLER) {
@@ -57,7 +64,7 @@ public class JarUtils {
                             outputStream.closeEntry()
                         }
                     }
-                    val includedFile = IncludedFile(From(source.path), To(""), listOf(IFileSpec.GlobSpec("**")))
+                    val includedFile = IncludedFile(From(source.path), To(""), listOf(GlobSpec("**")))
                     addSingleFile(".", includedFile, outputStream, expandJarFiles)
                 } else {
                     if (expandJarFiles and source.name.endsWith(".jar")) {
@@ -153,7 +160,7 @@ class IncludedFile(val fromOriginal: From, val toOriginal: To, val specs: List<I
     public val from: String get() = fromOriginal.path.replace("\\", "/")
     public val to: String get() = toOriginal.path.replace("\\", "/")
     override public fun toString() = toString("IncludedFile",
-            "files", specs.map { it.toString() }.joinToString(", "),
+            "files - ", specs.map { it.toString() },
             "from", from,
             "to", to)
 

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/KFiles.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/KFiles.kt
@@ -7,17 +7,20 @@ import com.beust.kobalt.internal.build.BuildFile
 import com.beust.kobalt.maven.Md5
 import java.io.File
 import java.io.IOException
-import java.nio.file.*
-import kotlin.io.FileAlreadyExistsException
-import kotlin.io.FileSystemException
-import kotlin.io.NoSuchFileException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import kotlin.collections.*
+import kotlin.text.contains
+import kotlin.text.substring
 
 class KFiles {
     /**
      * This actually returns a list of strings because in development mode, we are not pointing to a single
      * jar file but to a set of /classes directories.
      */
-    val kobaltJar : List<String>
+    val kobaltJar: List<String>
         get() {
             val envJar = System.getenv("KOBALT_JAR")
             if (envJar != null) {
@@ -45,8 +48,8 @@ class KFiles {
     }
 
     companion object {
-        internal const val KOBALT_DOT_DIR : String = ".kobalt"
-        const val KOBALT_DIR : String = "kobalt"
+        internal const val KOBALT_DOT_DIR: String = ".kobalt"
+        const val KOBALT_DIR: String = "kobalt"
         const val KOBALT_BUILD_DIR = "kobaltBuild"
 
         // Directories under ~/.kobalt
@@ -56,13 +59,13 @@ class KFiles {
         val distributionsDir = homeDir(KOBALT_DOT_DIR, "wrapper", "dist")
 
         // Directories under ./.kobalt
-        val SCRIPT_BUILD_DIR : String = "build"
-        val CLASSES_DIR : String = "classes"
+        val SCRIPT_BUILD_DIR: String = "build"
+        val CLASSES_DIR: String = "classes"
 
         /** Where build file and support source files go, under KOBALT_DIR */
         private val SRC = "src"
 
-        val TEST_CLASSES_DIR : String = "test-classes"
+        val TEST_CLASSES_DIR: String = "test-classes"
 
         private fun generatedDir(project: Project, variant: Variant)
                 = KFiles.joinDir(project.directory, project.buildDirectory, "generated", variant.toIntermediateDir())
@@ -104,11 +107,11 @@ class KFiles {
         fun makeDir(dir: String, s: String? = null) =
                 (if (s != null) File(dir, s) else File(dir)).apply { mkdirs() }
 
-        fun findRecursively(rootDir: File) : List<String> =
+        fun findRecursively(rootDir: File): List<String> =
                 findRecursively(rootDir, arrayListOf(), { s -> true })
 
         fun findRecursively(rootDir: File, directories: List<File>,
-                function: Function1<String, Boolean>): List<String> {
+                            function: Function1<String, Boolean>): List<String> {
             var result = arrayListOf<String>()
 
             val allDirs = arrayListOf<File>()
@@ -120,13 +123,13 @@ class KFiles {
 
             val seen = hashSetOf<java.nio.file.Path>()
             allDirs.forEach { dir ->
-                if (! dir.exists()) {
+                if (!dir.exists()) {
                     log(2, "Couldn't find directory $dir")
                 } else {
                     val files = findRecursively(dir, function)
                     files.map { Paths.get(it) }.forEach {
                         val rel = Paths.get(dir.path).relativize(it)
-                        if (! seen.contains(rel)) {
+                        if (!seen.contains(rel)) {
                             result.add(File(dir, rel.toFile().path).path)
                             seen.add(rel)
                         } else {
@@ -136,7 +139,7 @@ class KFiles {
                 }
             }
             // Return files relative to rootDir
-            val r = result.map { it.substring(rootDir.path.length + 1)}
+            val r = result.map { it.substring(rootDir.path.length + 1) }
             return r
         }
 
@@ -153,11 +156,11 @@ class KFiles {
         }
 
         fun copyRecursively(from: File, to: File, replaceExisting: Boolean = true, deleteFirst: Boolean = false,
-                onError: (File, IOException) -> OnErrorAction = { file, exception -> throw exception }) {
+                            onError: (File, IOException) -> OnErrorAction = { file, exception -> throw exception }) {
             // Need to wait until copyRecursively supports an overwrite: Boolean = false parameter
             // Until then, wipe everything first
             if (deleteFirst) to.deleteRecursively()
-//            to.mkdirs()
+            //            to.mkdirs()
             hackCopyRecursively(from, to, replaceExisting = replaceExisting, onError = onError)
         }
 
@@ -168,10 +171,10 @@ class KFiles {
          * Copy/pasted from kotlin/io/Utils.kt to add support for overwriting.
          */
         private fun hackCopyRecursively(from: File, dst: File,
-                replaceExisting: Boolean,
-                checkTimestamp: Boolean = false,
-                onError: (File, IOException) -> OnErrorAction =
-                { file, exception -> throw exception }
+                                        replaceExisting: Boolean,
+                                        checkTimestamp: Boolean = false,
+                                        onError: (File, IOException) -> OnErrorAction =
+                                        { file, exception -> throw exception }
         ): Boolean {
             if (!from.exists()) {
                 return onError(from, NoSuchFileException(file = from, reason = "The source file doesn't exist")) !=
@@ -213,9 +216,9 @@ class KFiles {
             }
         }
 
-        fun findDotDir(startDir: File) : File {
+        fun findDotDir(startDir: File): File {
             var result = startDir
-            while (result != null && ! File(result, KOBALT_DOT_DIR).exists()) {
+            while (result != null && !File(result, KOBALT_DOT_DIR).exists()) {
                 result = result.parentFile
             }
             if (result == null) {
@@ -227,7 +230,7 @@ class KFiles {
         /**
          * The build location for build scripts is .kobalt/build
          */
-        fun findBuildScriptLocation(buildFile: BuildFile, jarFile: String) : String {
+        fun findBuildScriptLocation(buildFile: BuildFile, jarFile: String): String {
             val result = joinDir(findDotDir(buildFile.directory).absolutePath, KFiles.SCRIPT_BUILD_DIR, jarFile)
             log(2, "Script jar file: $result")
             return result
@@ -261,41 +264,26 @@ class KFiles {
             }
         }
 
-        fun createTempFile(suffix : String = "", deleteOnExit: Boolean = false) : File =
-            File.createTempFile("kobalt", suffix, File(SystemProperties.tmpDir)).let {
-                if (deleteOnExit) it.deleteOnExit()
-                return it
-            }
+        fun createTempFile(suffix: String = "", deleteOnExit: Boolean = false): File =
+                File.createTempFile("kobalt", suffix, File(SystemProperties.tmpDir)).let {
+                    if (deleteOnExit) it.deleteOnExit()
+                    return it
+                }
 
         fun src(filePath: String): String = KFiles.joinDir(KOBALT_DIR, SRC, filePath)
 
-        fun makeDir(project: Project, suffix: String) : File {
+        fun makeDir(project: Project, suffix: String): File {
             return File(project.directory, project.buildDirectory + File.separator + suffix).apply { mkdirs() }
         }
 
-        fun makeOutputDir(project: Project) : File = makeDir(project, KFiles.CLASSES_DIR)
+        fun makeOutputDir(project: Project): File = makeDir(project, KFiles.CLASSES_DIR)
 
-        fun makeOutputTestDir(project: Project) : File = makeDir(project, KFiles.TEST_CLASSES_DIR)
+        fun makeOutputTestDir(project: Project): File = makeDir(project, KFiles.TEST_CLASSES_DIR)
 
-        fun isExcluded(file: File, excludes: List<IFileSpec.GlobSpec>) = isExcluded(file.path, excludes)
+        fun isExcluded(file: File, excludes: IFileSpec.GlobSpec) = isExcluded(file.path, excludes)
 
-        fun isExcluded(file: String, excludes: List<IFileSpec.GlobSpec>) : Boolean {
-            if (excludes.isEmpty()) {
-                return false
-            } else {
-                val ex = excludes.map {
-                    FileSystems.getDefault().getPathMatcher("glob:${it.spec}")
-                }
-                ex.forEach {
-                    if (it.matches(Paths.get(file))) {
-                        log(3, "Excluding $file")
-                        return true
-                    }
-                }
-            }
-            return false
-        }
-
+        fun isExcluded(file: String, excludes: IFileSpec.GlobSpec): Boolean =
+                if (excludes.toFile(file).isEmpty()) true else false
     }
 
     fun findRecursively(directory: File, function: Function1<String, Boolean>): List<String> {
@@ -303,7 +291,7 @@ class KFiles {
     }
 
     fun findRecursively(rootDir: File, directories: List<File>,
-            function: Function1<String, Boolean>): List<String> {
+                        function: Function1<String, Boolean>): List<String> {
         return KFiles.findRecursively(rootDir, directories, function)
     }
 }

--- a/src/main/kotlin/com/beust/kobalt/plugin/packaging/PackagingPlugin.kt
+++ b/src/main/kotlin/com/beust/kobalt/plugin/packaging/PackagingPlugin.kt
@@ -43,7 +43,7 @@ class PackagingPlugin @Inject constructor(val dependencyManager : DependencyMana
         const val TASK_INSTALL: String = "install"
 
 
-        fun findIncludedFiles(directory: String, files: List<IncludedFile>, excludes: List<IFileSpec.GlobSpec>)
+        fun findIncludedFiles(directory: String, files: List<IncludedFile>, excludes: IFileSpec.GlobSpec)
                 : List<IncludedFile> {
             val result = arrayListOf<IncludedFile>()
             files.forEach { includedFile ->
@@ -313,7 +313,7 @@ class PackageConfig(val project: Project) : AttributeHolder {
 
 open class Zip(open var name: String? = null) {
 //    internal val includes = arrayListOf<IFileSpec>()
-    internal val excludes = arrayListOf<GlobSpec>()
+    internal val excludes = GlobSpec(arrayListOf(), arrayListOf())
 
     @Directive
     public fun from(s: String) = From(s)
@@ -323,12 +323,12 @@ open class Zip(open var name: String? = null) {
 
     @Directive
     public fun exclude(vararg files: String) {
-        files.forEach { excludes.add(GlobSpec(it)) }
+        files.forEach { excludes.excludeSpec.add(it) }
     }
 
     @Directive
     public fun exclude(vararg specs: GlobSpec) {
-        specs.forEach { excludes.add(it) }
+        specs.forEach { excludes.excludeSpec.addAll(it.excludeSpec) }
     }
 
     @Directive


### PR DESCRIPTION
Added test directives to:
- Include desired globs (defaults to "**/*Test.class". Note that ".class" can be omitted.)
- Exclude desired globs (no default)
- Updated GlobSpec to do both include and exclude filtering. This allowed to quite a bit of code cleaning and simplification.
- Other minor improvements