### PR TITLE
fixed an issue with RunCommand output

### DIFF
--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/RunCommand.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/RunCommand.kt
@@ -53,7 +53,7 @@ open class RunCommand(val command: String) {
         val isSuccess = isSuccess(callSucceeded, input, error)
 
         if (isSuccess) {
-            successCallback(fromStream(process.inputStream))
+            successCallback(input)
         } else {
             errorCallback(error + input)
         }


### PR DESCRIPTION
Befor the fix the core read twise from the input stream, second time the stream was empty.
The affect was it that the output of any `run` command were not displayed in the console.