### PR TITLE
ADD_newVersionCheck_timeout

### DIFF
--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/api/Kobalt.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/api/Kobalt.kt
@@ -5,6 +5,7 @@ import com.beust.kobalt.HostConfig
 import com.beust.kobalt.Plugins
 import com.google.inject.Injector
 import java.io.InputStream
+import java.time.Duration
 import java.util.*
 
 public class Kobalt {
@@ -34,8 +35,9 @@ public class Kobalt {
                 if (repo.url.endsWith("/")) repo
                 else repo.copy(url = (repo.url + "/")))
 
-        private val PROPERTY_KOBALT_VERSION = "kobalt.version"
         private val KOBALT_PROPERTIES = "kobalt.properties"
+        private val PROPERTY_KOBALT_VERSION = "kobalt.version"
+        private val PROPERTY_KOBALT_VERSION_CHECK_TIMEOUT = "kobalt.version.check_timeout"  // ISO-8601
 
         /** kobalt.properties */
         private val kobaltProperties: Properties by lazy { readProperties() }
@@ -73,6 +75,7 @@ public class Kobalt {
         }
 
         val version = kobaltProperties.getProperty(PROPERTY_KOBALT_VERSION)
+        val versionCheckTimeout = Duration.parse(kobaltProperties.getProperty(PROPERTY_KOBALT_VERSION_CHECK_TIMEOUT))
 
         fun findPlugin(name: String) = Plugins.findPlugin(name)
     }

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/build/VersionCheckTimestampFile.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/build/VersionCheckTimestampFile.kt
@@ -1,0 +1,23 @@
+package com.beust.kobalt.internal.build
+
+import com.beust.kobalt.misc.KFiles
+import java.io.File
+import java.time.Instant
+
+class VersionCheckTimestampFile {
+    companion object {
+        private val KOBALT_VERSION_CHECK_TIMESTAMP_FILE = "versionCheckTimestamp.txt"
+        private val checkTimestampFile = File(KFiles.KOBALT_DOT_DIR, KOBALT_VERSION_CHECK_TIMESTAMP_FILE)
+
+        fun updateTimestamp(timestamp: Instant) = KFiles.saveFile(checkTimestampFile, timestamp.toString())
+
+        fun getTimestamp(): Instant {
+            return if(checkTimestampFile.exists())
+                Instant.parse(checkTimestampFile.readText())
+            else {
+                updateTimestamp(Instant.MIN)
+                Instant.MIN
+            }
+        }
+    }
+}

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/KobaltWrapperProperties.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/KobaltWrapperProperties.kt
@@ -4,7 +4,6 @@ import com.beust.kobalt.api.Kobalt
 import com.google.inject.Inject
 import java.io.File
 import java.io.FileReader
-import java.time.Instant
 import java.util.*
 
 /**
@@ -14,14 +13,12 @@ class KobaltWrapperProperties @Inject constructor() {
     private val WRAPPER_DIR = KFiles.KOBALT_DIR + "/wrapper"
     private val KOBALT_WRAPPER_PROPERTIES = "kobalt-wrapper.properties"
     private val PROPERTY_VERSION = "kobalt.version"
-    private val PROPERTY_VERSION_LAST_CHECKED = "kobalt.version.last_checked"
     private val PROPERTY_DOWNLOAD_URL = "kobalt.downloadUrl"
 
-    fun create(version: String, versionLastChecked: Instant) {
+    fun create(version: String) {
         log(2, "Creating $file with $version and ${defaultUrlFor(version)}")
         KFiles.saveFile(file, listOf(
-                "$PROPERTY_VERSION=$version",
-                "$PROPERTY_VERSION_LAST_CHECKED=$versionLastChecked"
+                "$PROPERTY_VERSION=$version"
 //                "$PROPERTY_DOWNLOAD_URL=${defaultUrlFor(version)}"
         ).joinToString("\n"))
     }
@@ -36,7 +33,7 @@ class KobaltWrapperProperties @Inject constructor() {
         get() {
             val config = file
             if (!config.exists()) {
-                create(Kobalt.version, Instant.MIN)
+                create(Kobalt.version)
             }
 
             val result = Properties()
@@ -46,9 +43,6 @@ class KobaltWrapperProperties @Inject constructor() {
 
     val version : String
         get() = properties.getProperty(PROPERTY_VERSION)
-
-    val versionLastChecked: Instant
-        get() = Instant.parse(properties.getProperty(PROPERTY_VERSION_LAST_CHECKED))
 
     val downloadUrl : String
         get() = properties.getProperty(PROPERTY_DOWNLOAD_URL)

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/KobaltWrapperProperties.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/KobaltWrapperProperties.kt
@@ -4,6 +4,7 @@ import com.beust.kobalt.api.Kobalt
 import com.google.inject.Inject
 import java.io.File
 import java.io.FileReader
+import java.sql.Timestamp
 import java.util.*
 
 /**
@@ -13,12 +14,14 @@ class KobaltWrapperProperties @Inject constructor() {
     private val WRAPPER_DIR = KFiles.KOBALT_DIR + "/wrapper"
     private val KOBALT_WRAPPER_PROPERTIES = "kobalt-wrapper.properties"
     private val PROPERTY_VERSION = "kobalt.version"
+    private val PROPERTY_VERSION_LAST_CHECKED = "kobalt.version.last_checked"
     private val PROPERTY_DOWNLOAD_URL = "kobalt.downloadUrl"
 
-    fun create(version: String) {
+    fun create(version: String, versionLastChecked: Timestamp) {
         log(2, "Creating $file with $version and ${defaultUrlFor(version)}")
         KFiles.saveFile(file, listOf(
-                "$PROPERTY_VERSION=$version"
+                "$PROPERTY_VERSION=$version",
+                "$PROPERTY_VERSION_LAST_CHECKED=$versionLastChecked"
 //                "$PROPERTY_DOWNLOAD_URL=${defaultUrlFor(version)}"
         ).joinToString("\n"))
     }
@@ -33,7 +36,7 @@ class KobaltWrapperProperties @Inject constructor() {
         get() {
             val config = file
             if (!config.exists()) {
-                create(Kobalt.version)
+                create(Kobalt.version, Timestamp(0))
             }
 
             val result = Properties()
@@ -43,6 +46,9 @@ class KobaltWrapperProperties @Inject constructor() {
 
     val version : String
         get() = properties.getProperty(PROPERTY_VERSION)
+
+    val versionLastChecked: Timestamp
+        get() = Timestamp.valueOf(properties.getProperty(PROPERTY_VERSION_LAST_CHECKED))
 
     val downloadUrl : String
         get() = properties.getProperty(PROPERTY_DOWNLOAD_URL)

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/KobaltWrapperProperties.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/KobaltWrapperProperties.kt
@@ -4,7 +4,7 @@ import com.beust.kobalt.api.Kobalt
 import com.google.inject.Inject
 import java.io.File
 import java.io.FileReader
-import java.sql.Timestamp
+import java.time.Instant
 import java.util.*
 
 /**
@@ -17,7 +17,7 @@ class KobaltWrapperProperties @Inject constructor() {
     private val PROPERTY_VERSION_LAST_CHECKED = "kobalt.version.last_checked"
     private val PROPERTY_DOWNLOAD_URL = "kobalt.downloadUrl"
 
-    fun create(version: String, versionLastChecked: Timestamp) {
+    fun create(version: String, versionLastChecked: Instant) {
         log(2, "Creating $file with $version and ${defaultUrlFor(version)}")
         KFiles.saveFile(file, listOf(
                 "$PROPERTY_VERSION=$version",
@@ -36,7 +36,7 @@ class KobaltWrapperProperties @Inject constructor() {
         get() {
             val config = file
             if (!config.exists()) {
-                create(Kobalt.version, Timestamp(0))
+                create(Kobalt.version, Instant.MIN)
             }
 
             val result = Properties()
@@ -47,8 +47,8 @@ class KobaltWrapperProperties @Inject constructor() {
     val version : String
         get() = properties.getProperty(PROPERTY_VERSION)
 
-    val versionLastChecked: Timestamp
-        get() = Timestamp.valueOf(properties.getProperty(PROPERTY_VERSION_LAST_CHECKED))
+    val versionLastChecked: Instant
+        get() = Instant.parse(properties.getProperty(PROPERTY_VERSION_LAST_CHECKED))
 
     val downloadUrl : String
         get() = properties.getProperty(PROPERTY_DOWNLOAD_URL)

--- a/src/main/kotlin/com/beust/kobalt/Main.kt
+++ b/src/main/kotlin/com/beust/kobalt/Main.kt
@@ -81,6 +81,7 @@ private class Main @Inject constructor(
 
         var result = 0
         val latestVersionFuture = github.latestKobaltVersion
+
         val seconds = benchmarkSeconds {
             try {
                 result = runWithArgs(jc, args, argv)
@@ -95,8 +96,7 @@ private class Main @Inject constructor(
         if (! args.update) {
             log(1, if (result != 0) "BUILD FAILED: $result" else "BUILD SUCCESSFUL ($seconds seconds)")
 
-            // Check for new version
-            updateKobalt.checkForNewVersion(latestVersionFuture.get())
+            updateKobalt.checkForNewVersion(latestVersionFuture)
         }
         return result
     }

--- a/src/main/kotlin/com/beust/kobalt/Main.kt
+++ b/src/main/kotlin/com/beust/kobalt/Main.kt
@@ -22,8 +22,6 @@ import com.google.inject.Guice
 import java.io.File
 import java.nio.file.Paths
 import java.util.*
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 
 public fun main(argv: Array<String>) {
@@ -98,24 +96,7 @@ private class Main @Inject constructor(
             log(1, if (result != 0) "BUILD FAILED: $result" else "BUILD SUCCESSFUL ($seconds seconds)")
 
             // Check for new version
-            try {
-                val latestVersionString = latestVersionFuture.get(1, TimeUnit.SECONDS)
-                val latestVersion = Versions.toLongVersion(latestVersionString)
-                val current = Versions.toLongVersion(Kobalt.version)
-                val distFile = File(KFiles.joinDir(KFiles.distributionsDir, latestVersionString))
-                if (latestVersion > current) {
-                    if (distFile.exists()) {
-                        log(1, "**** Version $latestVersionString is installed")
-                    } else {
-                        listOf("", "New Kobalt version available: $latestVersionString",
-                                "To update, run ./kobaltw --update", "").forEach {
-                            log(1, "**** $it")
-                        }
-                    }
-                }
-            } catch(ex: TimeoutException) {
-                log(2, "Didn't get the new version in time, skipping it")
-            }
+            updateKobalt.checkForNewVersion(latestVersionFuture.get())
         }
         return result
     }

--- a/src/main/kotlin/com/beust/kobalt/app/UpdateKobalt.kt
+++ b/src/main/kotlin/com/beust/kobalt/app/UpdateKobalt.kt
@@ -6,6 +6,7 @@ import com.beust.kobalt.wrapper.Main
 import java.io.File
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.Future
 import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 
@@ -26,12 +27,16 @@ public class UpdateKobalt @Inject constructor(val github: GithubApi, val wrapper
         Main.main(arrayOf("--download", "--no-launch"))
     }
 
-    fun checkForNewVersion(latestVersionString: String) {
+    /**
+     * Accepts Future<String> as `latestVersionFuture` to allow getting `latestVersion` in the background
+     * */
+    fun checkForNewVersion(latestVersionFuture: Future<String>) {
         if(Kobalt.versionCheckTimeout
                 > Duration.between(wrapperProperties.versionLastChecked, Instant.now()))
             return  // waits `Kobalt.versionCheckTimeout` before the next check
 
         try {
+            val latestVersionString = latestVersionFuture.get()
             val latestVersion = Versions.toLongVersion(latestVersionString)
             val current = Versions.toLongVersion(Kobalt.version)
             val distFile = File(KFiles.joinDir(KFiles.distributionsDir, latestVersionString))

--- a/src/main/kotlin/com/beust/kobalt/app/UpdateKobalt.kt
+++ b/src/main/kotlin/com/beust/kobalt/app/UpdateKobalt.kt
@@ -4,6 +4,7 @@ import com.beust.kobalt.api.Kobalt
 import com.beust.kobalt.misc.*
 import com.beust.kobalt.wrapper.Main
 import java.io.File
+import java.sql.Timestamp
 import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 
@@ -13,7 +14,7 @@ import javax.inject.Inject
 public class UpdateKobalt @Inject constructor(val github: GithubApi, val wrapperProperties: KobaltWrapperProperties) {
     fun updateKobalt() {
         val newVersion = github.latestKobaltVersion
-        wrapperProperties.create(newVersion.get())
+        wrapperProperties.create(newVersion.get(), Timestamp(System.currentTimeMillis()))
         Main.main(arrayOf())
     }
 
@@ -39,6 +40,7 @@ public class UpdateKobalt @Inject constructor(val github: GithubApi, val wrapper
                     }
                 }
             }
+            wrapperProperties.create(wrapperProperties.version, Timestamp(System.currentTimeMillis()))
         } catch(ex: TimeoutException) {
             log(2, "Didn't get the new version in time, skipping it")
         }

--- a/src/main/kotlin/com/beust/kobalt/app/UpdateKobalt.kt
+++ b/src/main/kotlin/com/beust/kobalt/app/UpdateKobalt.kt
@@ -1,8 +1,10 @@
 package com.beust.kobalt.app
 
-import com.beust.kobalt.misc.GithubApi
-import com.beust.kobalt.misc.KobaltWrapperProperties
+import com.beust.kobalt.api.Kobalt
+import com.beust.kobalt.misc.*
 import com.beust.kobalt.wrapper.Main
+import java.io.File
+import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 
 /**
@@ -20,5 +22,25 @@ public class UpdateKobalt @Inject constructor(val github: GithubApi, val wrapper
      */
     fun downloadKobalt() {
         Main.main(arrayOf("--download", "--no-launch"))
+    }
+
+    fun checkForNewVersion(latestVersionString: String) {
+        try {
+            val latestVersion = Versions.toLongVersion(latestVersionString)
+            val current = Versions.toLongVersion(Kobalt.version)
+            val distFile = File(KFiles.joinDir(KFiles.distributionsDir, latestVersionString))
+            if (latestVersion > current) {
+                if (distFile.exists()) {
+                    log(1, "**** Version $latestVersionString is installed")
+                } else {
+                    listOf("", "New Kobalt version available: $latestVersionString",
+                            "To update, run ./kobaltw --update", "").forEach {
+                        log(1, "**** $it")
+                    }
+                }
+            }
+        } catch(ex: TimeoutException) {
+            log(2, "Didn't get the new version in time, skipping it")
+        }
     }
 }

--- a/src/main/kotlin/com/beust/kobalt/app/UpdateKobalt.kt
+++ b/src/main/kotlin/com/beust/kobalt/app/UpdateKobalt.kt
@@ -4,6 +4,7 @@ import com.beust.kobalt.api.Kobalt
 import com.beust.kobalt.misc.*
 import com.beust.kobalt.wrapper.Main
 import java.io.File
+import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.TimeoutException
 import javax.inject.Inject
@@ -26,6 +27,10 @@ public class UpdateKobalt @Inject constructor(val github: GithubApi, val wrapper
     }
 
     fun checkForNewVersion(latestVersionString: String) {
+        if(Kobalt.versionCheckTimeout
+                > Duration.between(wrapperProperties.versionLastChecked, Instant.now()))
+            return  // waits `Kobalt.versionCheckTimeout` before the next check
+
         try {
             val latestVersion = Versions.toLongVersion(latestVersionString)
             val current = Versions.toLongVersion(Kobalt.version)

--- a/src/main/kotlin/com/beust/kobalt/app/UpdateKobalt.kt
+++ b/src/main/kotlin/com/beust/kobalt/app/UpdateKobalt.kt
@@ -1,6 +1,7 @@
 package com.beust.kobalt.app
 
 import com.beust.kobalt.api.Kobalt
+import com.beust.kobalt.internal.build.VersionCheckTimestampFile
 import com.beust.kobalt.misc.*
 import com.beust.kobalt.wrapper.Main
 import java.io.File
@@ -16,7 +17,8 @@ import javax.inject.Inject
 public class UpdateKobalt @Inject constructor(val github: GithubApi, val wrapperProperties: KobaltWrapperProperties) {
     fun updateKobalt() {
         val newVersion = github.latestKobaltVersion
-        wrapperProperties.create(newVersion.get(), Instant.now())
+        wrapperProperties.create(newVersion.get())
+        VersionCheckTimestampFile.updateTimestamp(Instant.now())
         Main.main(arrayOf())
     }
 
@@ -32,7 +34,7 @@ public class UpdateKobalt @Inject constructor(val github: GithubApi, val wrapper
      * */
     fun checkForNewVersion(latestVersionFuture: Future<String>) {
         if(Kobalt.versionCheckTimeout
-                > Duration.between(wrapperProperties.versionLastChecked, Instant.now()))
+                > Duration.between(VersionCheckTimestampFile.getTimestamp(), Instant.now()))
             return  // waits `Kobalt.versionCheckTimeout` before the next check
 
         try {
@@ -50,7 +52,7 @@ public class UpdateKobalt @Inject constructor(val github: GithubApi, val wrapper
                     }
                 }
             }
-            wrapperProperties.create(wrapperProperties.version, Instant.now())
+            VersionCheckTimestampFile.updateTimestamp(Instant.now())
         } catch(ex: TimeoutException) {
             log(2, "Didn't get the new version in time, skipping it")
         }

--- a/src/main/kotlin/com/beust/kobalt/app/UpdateKobalt.kt
+++ b/src/main/kotlin/com/beust/kobalt/app/UpdateKobalt.kt
@@ -4,7 +4,7 @@ import com.beust.kobalt.api.Kobalt
 import com.beust.kobalt.misc.*
 import com.beust.kobalt.wrapper.Main
 import java.io.File
-import java.sql.Timestamp
+import java.time.Instant
 import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 
@@ -14,7 +14,7 @@ import javax.inject.Inject
 public class UpdateKobalt @Inject constructor(val github: GithubApi, val wrapperProperties: KobaltWrapperProperties) {
     fun updateKobalt() {
         val newVersion = github.latestKobaltVersion
-        wrapperProperties.create(newVersion.get(), Timestamp(System.currentTimeMillis()))
+        wrapperProperties.create(newVersion.get(), Instant.now())
         Main.main(arrayOf())
     }
 
@@ -40,7 +40,7 @@ public class UpdateKobalt @Inject constructor(val github: GithubApi, val wrapper
                     }
                 }
             }
-            wrapperProperties.create(wrapperProperties.version, Timestamp(System.currentTimeMillis()))
+            wrapperProperties.create(wrapperProperties.version, Instant.now())
         } catch(ex: TimeoutException) {
             log(2, "Didn't get the new version in time, skipping it")
         }

--- a/src/main/resources/kobalt.properties
+++ b/src/main/resources/kobalt.properties
@@ -1,1 +1,2 @@
 kobalt.version=0.401
+kobalt.version.check_timeout=P1DT2H


### PR DESCRIPTION
Adds a kobalt property `kobalt.version.check_timeout` which specifies a period of time to wait since the last kobalt version check befor the next one.
This removes a delay after each compilation (or any other command), because the network operations are performed only onece a `timeout`
I set the value to be `P1DT2H`, which corresponds to one day two hours (ISO-8601)
Note that the network timeout may be increased