### PR TITLE
+ Proxy support in kobalt-settings: <proxy>      <host>somehost</host>      <port>3128</port>      <type>http</type>      <!--<type>https</type>-->  </proxy>

### DIFF
--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/BuildScript.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/BuildScript.kt
@@ -30,6 +30,8 @@ fun plugins(vararg dependencies : String) {
     }
 }
 
+data class ProxyConfig(var host: String = "", var port: Int = 0, val type: String = "")
+
 data class HostConfig(var url: String = "", var username: String? = null, var password: String? = null) {
     fun hasAuth() : Boolean {
         return (! username.isNullOrBlank()) && (! password.isNullOrBlank())

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/api/Kobalt.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/api/Kobalt.kt
@@ -3,8 +3,11 @@ package com.beust.kobalt.api
 import com.beust.kobalt.Constants
 import com.beust.kobalt.HostConfig
 import com.beust.kobalt.Plugins
+import com.beust.kobalt.ProxyConfig
 import com.google.inject.Injector
+import org.eclipse.aether.repository.Proxy
 import java.io.InputStream
+import java.net.InetSocketAddress
 import java.time.Duration
 import java.util.*
 
@@ -13,6 +16,18 @@ class Kobalt {
         lateinit var INJECTOR : Injector
 
         var context: KobaltContext? = null
+
+        val proxyConfig = with(Kobalt.context?.settings?.proxy) {
+                if (this != null) {
+                    ProxyConfig(host, port.toIntOr(0), type)
+                } else null
+            }
+
+        fun String.toIntOr(defaultValue: Int) = try {   //TODO can be extracted to some global Utils
+            toInt()
+        } catch(e: NumberFormatException) {
+            defaultValue
+        }
 
         /**
          * @return the repos calculated from the following places:
@@ -99,3 +114,10 @@ class Kobalt {
         fun findPlugin(name: String) = Plugins.findPlugin(name)
     }
 }
+
+
+fun ProxyConfig?.toProxy() = if (this != null) {
+    java.net.Proxy(java.net.Proxy.Type.HTTP, InetSocketAddress(host, port))
+} else null
+
+fun ProxyConfig?.toAetherProxy() = if (this != null) Proxy(type, host, port) else null //TODO make support for proxy auth

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/KobaltSettingsXml.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/KobaltSettingsXml.kt
@@ -22,11 +22,25 @@ class KobaltSettingsXml {
     @XmlElement(name = "default-repos") @JvmField
     var defaultRepos: DefaultReposXml? = null
 
+    @XmlElement(name = "proxy") @JvmField
+    var proxy: ProxyXml? = null
+
     @XmlElement(name = "kobalt-compiler-version") @JvmField
     var kobaltCompilerVersion: String = "1.0.0"
 
     @XmlElement(name = "kobalt-compiler-repo") @JvmField
     var kobaltCompilerRepo: String? = null
+}
+
+class ProxyXml {
+    @XmlElement @JvmField
+    var host: String = ""
+
+    @XmlElement @JvmField
+    var port: String = ""
+
+    @XmlElement @JvmField
+    var type: String = ""
 }
 
 class DefaultReposXml {
@@ -45,6 +59,8 @@ class KobaltSettings @Inject constructor(val xmlFile: KobaltSettingsXml) {
     var localRepo = KFiles.makeDir(xmlFile.localRepo) // var for testing
 
     val defaultRepos = xmlFile.defaultRepos?.repo
+
+    val proxy = xmlFile.proxy
 
     var kobaltCompilerVersion = xmlFile.kobaltCompilerVersion
     var kobaltCompilerRepo = xmlFile.kobaltCompilerRepo

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/maven/Http.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/maven/Http.kt
@@ -1,6 +1,8 @@
 package com.beust.kobalt.maven
 
 import com.beust.kobalt.KobaltException
+import com.beust.kobalt.api.Kobalt
+import com.beust.kobalt.api.toProxy
 import com.beust.kobalt.misc.CountingFileRequestBody
 import com.beust.kobalt.misc.log
 import okhttp3.*
@@ -19,7 +21,7 @@ class Http {
     }
 
     fun get(user: String?, password: String?, url: String) : Response {
-        val client = OkHttpClient()
+        val client = OkHttpClient.Builder().proxy(Kobalt.proxyConfig.toProxy()).build()
         val request = Request.Builder().url(url)
         if (user != null) {
             request.header("Authorization", Credentials.basic(user, password))
@@ -73,7 +75,7 @@ class Http {
             .build()
 
         log(2, "Uploading $file to $url")
-        val response = OkHttpClient().newCall(request).execute()
+        val response = OkHttpClient.Builder().proxy(Kobalt.proxyConfig.toProxy()).build().newCall(request).execute()
         if (! response.isSuccessful) {
             error(response)
         } else {

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/maven/aether/Aether.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/maven/aether/Aether.kt
@@ -3,6 +3,7 @@ package com.beust.kobalt.maven.aether
 import com.beust.kobalt.KobaltException
 import com.beust.kobalt.api.IClasspathDependency
 import com.beust.kobalt.api.Kobalt
+import com.beust.kobalt.api.toAetherProxy
 import com.beust.kobalt.homeDir
 import com.beust.kobalt.internal.KobaltSettings
 import com.beust.kobalt.internal.KobaltSettingsXml
@@ -80,6 +81,7 @@ class Aether(val localRepo: File) {
     private val kobaltRepositories : List<RemoteRepository>
             get() = Kobalt.repos.map {
                 RemoteRepository.Builder("maven", "default", it.url)
+                        .setProxy(Kobalt.proxyConfig.toAetherProxy())
 //                    .setSnapshotPolicy(RepositoryPolicy(false, null, null))
                     .build()
             }

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/CountingFileRequestBody.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/CountingFileRequestBody.kt
@@ -54,7 +54,7 @@ class CountingFileRequestBody(val file: File, val contentType: String,
 //                    //                    .post(requestBody)
 //                    .build();
 //
-//            val response = OkHttpClient().newCall(request).execute()
+//            val response = OkHttpClient.Builder().proxy(Kobalt.proxyConfig.toProxy()).build().newCall(request).execute()
 //            if (! response.isSuccessful) {
 //                println("ERROR")
 //            } else {

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/GithubApi2.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/GithubApi2.kt
@@ -1,6 +1,8 @@
 package com.beust.kobalt.misc
 
 import com.beust.kobalt.KobaltException
+import com.beust.kobalt.api.Kobalt
+import com.beust.kobalt.api.toProxy
 import com.beust.kobalt.internal.DocUrl
 import com.beust.kobalt.maven.Http
 import com.google.gson.Gson
@@ -58,7 +60,7 @@ class GithubApi2 @Inject constructor(
     // Read only Api
     //
     private val service = Retrofit.Builder()
-            .client(OkHttpClient())
+            .client(OkHttpClient.Builder().proxy(Kobalt.proxyConfig.toProxy()).build())
             .baseUrl("https://api.github.com")
             .addConverterFactory(GsonConverterFactory.create())
             .build()


### PR DESCRIPTION
+ Proxy support in kobalt-settings:
`<proxy>
     <host>somehost</host>
     <port>3128</port>
     <type>http</type>
     <!--<type>https</type>-->
 </proxy>`