### PR TITLE
Bug/194 npe - Absolute dir must not be computed

### DIFF
--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/build/BuildFile.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/build/BuildFile.kt
@@ -28,5 +28,5 @@ class BuildFile(val path: Path, val name: String, val realPath: Path = path) {
      * @return the absolute directory of this projects' location, assuming the build file is in
      * $project/kobalt/src/Build.kt.
      */
-    val absoluteDir = path.parent.parent.parent.toFile()
+    val absoluteDir: File? = path.parent?.parent?.parent?.toFile()
 }


### PR DESCRIPTION
@cbeust 

With the patch you did it works :+1: 

Solves https://github.com/cbeust/kobalt/issues/194
