### PR TITLE
* file encoding should be set. This will allow to inherit the right encoding from process which execute wrapper. This will fix invalid encoding on Windows (Ancii art drawing in Kobalt logger)

### DIFF
--- a/modules/wrapper/src/main/java/com/beust/kobalt/wrapper/Main.java
+++ b/modules/wrapper/src/main/java/com/beust/kobalt/wrapper/Main.java
@@ -3,6 +3,7 @@ package com.beust.kobalt.wrapper;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.file.*;
 import java.util.*;
 import java.util.zip.ZipEntry;
@@ -460,6 +461,7 @@ public class Main {
     private int launchMain(Path kobaltJarFile, String[] argv) throws IOException, InterruptedException {
         List<String> args = new ArrayList<>();
         args.add("java");
+        args.add("-Dfile.encoding=" + Charset.defaultCharset().name());
         args.add("-jar");
         args.add(kobaltJarFile.toFile().getAbsolutePath());
         Collections.addAll(args, argv);


### PR DESCRIPTION
* file encoding should be set. This will allow to inherit the right encoding from process which execute wrapper.
This will fix invalid encoding on Windows (Ancii art drawing in Kobalt logger)