### PR TITLE
fixed creation of classes directory at wrong parent

### DIFF
--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/CompilerUtils.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/CompilerUtils.kt
@@ -76,7 +76,7 @@ class CompilerUtils @Inject constructor(val files: KFiles,
 
         val buildDirectory = if (isTest) File(project.buildDirectory, KFiles.TEST_CLASSES_DIR)
         else File(project.classesDir(context))
-        buildDirectory.mkdirs()
+        File(project.directory, buildDirectory.path).mkdirs()
 
         val initialSourceDirectories = ArrayList<File>(sourceDirectories)
         // Source directories from the contributors

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/Io.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/Io.kt
@@ -73,7 +73,7 @@ class Io(val dryRun: Boolean = false) {
     }
 
     fun mkdir(dir: File) {
-        log("rm -rf $dir")
+        log("mkdir $dir")
         if (! dryRun) {
             dir.mkdirs()
         }


### PR DESCRIPTION
I'm using central build output directory `<workspace>/build` (for all projects) by using `../` in `project.buildDirectory`:
```
val p1 = project {
    name = "p1"
    directory = "p1"
    buildDirectory = "../build/p1"
}
```
This works fine except that Kobalt creates unused empty directories outside of the `<workspace>`directory.

This PR fixes this