### PR TITLE
fixed fatJar for projects in subdirectories that depend on other projects

### DIFF
--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/JarGenerator.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/JarGenerator.kt
@@ -107,7 +107,7 @@ class JarGenerator @Inject constructor(val dependencyManager: DependencyManager)
                 if (! seen.contains(file.path)) {
                     seen.add(file.path)
                     if (! KFiles.Companion.isExcluded(file, jar.excludes)) {
-                        result.add(IncludedFile(specs = arrayListOf(IFileSpec.FileSpec(file.path)),
+                        result.add(IncludedFile(specs = arrayListOf(IFileSpec.FileSpec(file.absolutePath)),
                                 expandJarFiles = true))
                     }
                 }

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/JarUtils.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/JarUtils.kt
@@ -47,12 +47,12 @@ public class JarUtils {
                     throw AssertionError("File should exist: $localFile")
                 }
 
-                if (foundFile.isDirectory) {
+                if (localFile.isDirectory) {
                     log(2, "Writing contents of directory $foundFile")
 
                     // Directory
-                    val includedFile = IncludedFile(From(foundFile.path), To(""), listOf(IFileSpec.GlobSpec("**")))
-                    addSingleFile(".", includedFile, outputStream, expandJarFiles)
+                    val includedFile = IncludedFile(From(""), To(""), listOf(IFileSpec.GlobSpec("**")))
+                    addSingleFile(localFile.path, includedFile, outputStream, expandJarFiles)
                 } else {
                     if (file.expandJarFiles && foundFile.name.endsWith(".jar") && ! file.from.contains("resources")) {
                         log(2, "Writing contents of jar file $foundFile")

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/JarUtils.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/JarUtils.kt
@@ -51,19 +51,6 @@ public class JarUtils {
                     log(2, "Writing contents of directory $foundFile")
 
                     // Directory
-                    var name = foundFile.name
-                    if (!name.isEmpty()) {
-                        if (!name.endsWith("/")) name += "/"
-                        val entry = JarEntry(name)
-                        entry.time = localFile.lastModified()
-                        try {
-                            outputStream.putNextEntry(entry)
-                        } catch(ex: ZipException) {
-                            log(2, "Can't add $name: ${ex.message}")
-                        } finally {
-                            outputStream.closeEntry()
-                        }
-                    }
                     val includedFile = IncludedFile(From(foundFile.path), To(""), listOf(IFileSpec.GlobSpec("**")))
                     addSingleFile(".", includedFile, outputStream, expandJarFiles)
                 } else {


### PR DESCRIPTION
E.g. building p2 (see below) failed with
  `java.lang.AssertionError: File should exist: p2\p1\kobaltBuild\classes`
because `p2.directory is != "."`

```
val p1 = project {
	name = "p1"
	directory = name
}

val p2 = project(p1) {
	name = "p2"
	directory = name
	assemble {
		jar {
			fatJar = true
		}
	}
}
```