### PR TITLE
no longer iterate over projects in TaskManager.installDynamicTasks()

### DIFF
--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/TaskManager.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/TaskManager.kt
@@ -419,11 +419,9 @@ class TaskManager @Inject constructor(val args: Args,
 
     private fun installDynamicTasks(projects: List<Project>) {
         dynamicTasks.forEach { task ->
-            projects.filter { task.plugin.accept(it) }.forEach { project ->
-                addTask(task.plugin, project, task.name, task.doc, task.group,
-                        task.dependsOn, task.reverseDependsOn, task.runBefore, task.runAfter, task.alwaysRunAfter,
-                        task.closure)
-            }
+            addTask(task.plugin, task.project, task.name, task.doc, task.group,
+                    task.dependsOn, task.reverseDependsOn, task.runBefore, task.runAfter, task.alwaysRunAfter,
+                    task.closure)
         }
     }
 


### PR DESCRIPTION
as discussed in issue #244: https://github.com/cbeust/kobalt/issues/244#issuecomment-225211217

All tests passed