### PR TITLE
delete temporary "kobalt123.kt" files (in temp folder)

### DIFF
--- a/src/main/kotlin/com/beust/kobalt/app/BuildFileCompiler.kt
+++ b/src/main/kotlin/com/beust/kobalt/app/BuildFileCompiler.kt
@@ -90,12 +90,11 @@ public class BuildFileCompiler @Inject constructor(@Assisted("buildFiles") val b
 
             // Write the modified Build.kt (e.g. maybe profiles were applied) to a temporary file,
             // compile it, jar it in buildScript.jar and run it
-            val modifiedBuildFile = KFiles.createTempFile(".kt")
+            val modifiedBuildFile = KFiles.createTempFile(".kt", deleteOnExit = true)
             KFiles.saveFile(modifiedBuildFile, parsedBuildFile.buildScriptCode)
             val taskResult = maybeCompileBuildFile(context, BuildFile(Paths.get(modifiedBuildFile.path),
                     "Modified ${Constants.BUILD_FILE_NAME}", buildFile.realPath),
                     buildScriptJarFile, pluginUrls)
-            modifiedBuildFile.delete()
             if (taskResult.success) {
                 projects.addAll(buildScriptUtil.runBuildScriptJarFile(buildScriptJarFile, pluginUrls, context))
             } else {

--- a/src/main/kotlin/com/beust/kobalt/app/BuildFileCompiler.kt
+++ b/src/main/kotlin/com/beust/kobalt/app/BuildFileCompiler.kt
@@ -95,6 +95,7 @@ public class BuildFileCompiler @Inject constructor(@Assisted("buildFiles") val b
             val taskResult = maybeCompileBuildFile(context, BuildFile(Paths.get(modifiedBuildFile.path),
                     "Modified ${Constants.BUILD_FILE_NAME}", buildFile.realPath),
                     buildScriptJarFile, pluginUrls)
+            modifiedBuildFile.delete()
             if (taskResult.success) {
                 projects.addAll(buildScriptUtil.runBuildScriptJarFile(buildScriptJarFile, pluginUrls, context))
             } else {

--- a/src/main/kotlin/com/beust/kobalt/app/ParsedBuildFile.kt
+++ b/src/main/kotlin/com/beust/kobalt/app/ParsedBuildFile.kt
@@ -121,6 +121,7 @@ class ParsedBuildFile(val buildFile: BuildFile, val context: KobaltContext, val 
             VersionFile.generateVersionFile(buildScriptJarFile.parentFile)
             Kobalt.context!!.internalContext.buildFileOutOfDate = true
         }
+        pluginSourceFile.delete()
 
         //
         // Run preBuildScript.jar to initialize plugins and repos

--- a/src/main/kotlin/com/beust/kobalt/app/ParsedBuildFile.kt
+++ b/src/main/kotlin/com/beust/kobalt/app/ParsedBuildFile.kt
@@ -105,7 +105,7 @@ class ParsedBuildFile(val buildFile: BuildFile, val context: KobaltContext, val 
         // Compile and run preBuildScriptCode, which contains all the plugins() calls extracted. This
         // will add all the dynamic plugins found in this code to Plugins.dynamicPlugins
         //
-        val pluginSourceFile = KFiles.createTempFile(".kt")
+        val pluginSourceFile = KFiles.createTempFile(".kt", deleteOnExit = true)
         pluginSourceFile.writeText(preBuildScriptCode, Charset.defaultCharset())
         log(2, "Saved ${pluginSourceFile.absolutePath}")
 
@@ -121,7 +121,6 @@ class ParsedBuildFile(val buildFile: BuildFile, val context: KobaltContext, val 
             VersionFile.generateVersionFile(buildScriptJarFile.parentFile)
             Kobalt.context!!.internalContext.buildFileOutOfDate = true
         }
-        pluginSourceFile.delete()
 
         //
         // Run preBuildScript.jar to initialize plugins and repos


### PR DESCRIPTION
When running kobalt it writes `kobalt123.kt` files to the temp folder, but never removes them.
Had already several thousand such files.