### PR TITLE
use timestamp checksum for files in `filesOrDirectories` parameter

### DIFF
--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/maven/Md5.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/maven/Md5.kt
@@ -25,13 +25,12 @@ public class Md5 {
          */
         fun toMd5Directories(filesOrDirectories: List<File>,
                 toBytes: (File) -> ByteArray = { it.lastModified().toString().toByteArray() } ): String? {
-            val ds = filesOrDirectories.filter { it.exists() }
-            if (ds.size > 0) {
+            if (filesOrDirectories.any { it.exists() }) {
                 MessageDigest.getInstance("MD5").let { md5 ->
                     var fileCount = 0
                     filesOrDirectories.filter { it.exists() }.forEach { file ->
                         if (file.isFile) {
-                            val bytes = file.readBytes()
+                            val bytes = toBytes(file)
                             md5.update(bytes, 0, bytes.size)
                             fileCount++
                         } else {

--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/maven/Md5.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/maven/Md5.kt
@@ -30,6 +30,7 @@ public class Md5 {
                     var fileCount = 0
                     filesOrDirectories.filter { it.exists() }.forEach { file ->
                         if (file.isFile) {
+                            log(2, "      Calculating checksum of $file")
                             val bytes = toBytes(file)
                             md5.update(bytes, 0, bytes.size)
                             fileCount++


### PR DESCRIPTION
If passing a file (e.g. a ZIP) to `Md5.toMd5Directories()` then it still used file content for the checksum. 

This PR changes that to using timestamps.