### PR TITLE
BuildScriptUtil.runBuildScriptJarFile(): do not invoke static getter that expects parameters

### DIFF
--- a/src/main/kotlin/com/beust/kobalt/app/BuildScriptUtil.kt
+++ b/src/main/kotlin/com/beust/kobalt/app/BuildScriptUtil.kt
@@ -79,7 +79,7 @@ class BuildScriptUtil @Inject constructor(val plugins: Plugins, val files: KFile
             }.forEach { cls ->
                 cls.methods.forEach { method ->
                     // Invoke vals and see if they return a Project
-                    if (method.name.startsWith("get") && Modifier.isStatic(method.modifiers)) {
+                    if (method.name.startsWith("get") && Modifier.isStatic(method.modifiers) && method.parameterCount == 0) {
                         try {
                             val r = method.invoke(null)
                             if (r is Project) {


### PR DESCRIPTION
fixes "ERROR wrong number of arguments" if adding property with getter to `Build.kt`. E.g.

```kobalt
val Project.libs: String
    get() = "$directory/$buildDirectory/libs"
```