### PR TITLE
Fix kobatlw shebang for Cygwin/MinGW.

### DIFF
--- a/modules/wrapper/src/main/java/com/beust/kobalt/wrapper/Main.java
+++ b/modules/wrapper/src/main/java/com/beust/kobalt/wrapper/Main.java
@@ -271,13 +271,13 @@ public class Main {
         // For kobaltw: try to generate it with the correct env shebang.
         //
         File envFile = new File("/bin/env");
-        if (!envFile.exists()) {
+        if (!envFile.canExecute()) {
             envFile = new File("/usr/bin/env");
         }
 
         String content = "";
 
-        content = "#!" + envFile.getAbsolutePath() + " bash\n";
+        content = "#!" + envFile.getPath() + " bash\n";
         
         log(2, "  Generating " + KOBALTW + " with shebang.");
 


### PR DESCRIPTION
Previous fix #279 broke under Gygwin and MinGW.

Tested under Gygwin, MinGW and Linux. Feel free to test under OS X. It'll work. ;-)