### PR TITLE
Batch file installation (Take 2)

### DIFF
--- a/dist/kobaltw
+++ b/dist/kobaltw
@@ -1,2 +1,2 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 java -jar $(dirname $0)/../kobalt/wrapper/kobalt-wrapper.jar $*

--- a/dist/kobaltw.bat
+++ b/dist/kobaltw.bat
@@ -1,2 +1,4 @@
 @echo off
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
 java -jar "%~dp0/../kobalt/wrapper/kobalt-wrapper.jar" %*

--- a/kobaltw
+++ b/kobaltw
@@ -1,2 +1,2 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 java -jar $(dirname $0)/kobalt/wrapper/kobalt-wrapper.jar $*


### PR DESCRIPTION
I changed #284 to handle Windows specifically. 

As discussed before, ``kobaltw.bat`` is now also created/installed by default.  It won't be overwritten if it already exists.

As also discussed, I switched ``kobaltw`` to the `bourne shell` as there is no longer anything specific to ``bash`` in it.