### PR TITLE
Fixed jGit complaining and not tagging if setAnnotated(false)

### DIFF
--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/Git.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/Git.kt
@@ -31,7 +31,12 @@ class Git @Inject constructor() {
                     .findGitDir()
                     .build()
             val git = org.eclipse.jgit.api.Git(repo)
-            val ref = git.tag().setAnnotated(annotated).setName(version).setMessage(message).call()
+            // jGit library will complain and not tag if setAnnotated(false)
+            var ref = if (annotated) {
+                git.tag().setAnnotated(annotated).setName(version).setMessage(message).call()
+            } else {
+                git.tag().setName(version).setMessage(message).call()
+            }
             git.push().setPushTags().call()
             true
         } catch(ex: Exception) {


### PR DESCRIPTION
jGIt would not tag and complain:

`***** WARNING Unannotated tags cannot have a message or tagger`

whenever `setAnnotated(false)`
