### PR TITLE
Properly handle symlink

### DIFF
--- a/dist/kobaltw
+++ b/dist/kobaltw
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-java -jar "`dirname "$0"`/../kobalt/wrapper/kobalt-wrapper.jar" $*
+java -jar "`dirname "$(readlink -f "$0")"`/../kobalt/wrapper/kobalt-wrapper.jar" $*

--- a/dist/kobaltw
+++ b/dist/kobaltw
@@ -1,2 +1,7 @@
 #!/usr/bin/env sh
-java -jar "`dirname "$(readlink -f "$0")"`/../kobalt/wrapper/kobalt-wrapper.jar" $*
+
+DIRNAME=`dirname $(readlink -f "$0")`
+if [[ "$(uname)" == "CYGWIN"* ]]; then
+    DIRNAME=`cygpath -d "$DIRNAME"`
+fi
+java -jar "${DIRNAME}/../kobalt/wrapper/kobalt-wrapper.jar" $*

--- a/modules/wrapper/src/main/java/com/beust/kobalt/wrapper/Main.java
+++ b/modules/wrapper/src/main/java/com/beust/kobalt/wrapper/Main.java
@@ -221,17 +221,17 @@ public class Main {
             }
 
             //
-            // Install the launcher if not already found.
+            // Install the launcher(s) if not already found.
             //
             File kobaltw = new File(KOBALTW);
-            File kobaltw_bat = new File(KOBALTW_BAT);
+            File kobaltwBat = new File(KOBALTW_BAT);
 
             if (!kobaltw.exists()) {
                 generateKobaltW(kobaltw.toPath());
             }
 
-            if (!kobaltw_bat.exists()) {
-                generateKobaltWBat(kobaltw_bat.toPath());
+            if (!kobaltwBat.exists()) {
+                generateKobaltWBat(kobaltwBat.toPath());
             }
         }
 

--- a/modules/wrapper/src/main/java/com/beust/kobalt/wrapper/Main.java
+++ b/modules/wrapper/src/main/java/com/beust/kobalt/wrapper/Main.java
@@ -219,6 +219,20 @@ public class Main {
                 log(2, "  Couldn't find $VERSION_TEXT, overwriting the installed wrapper");
                 installWrapperFiles(version, wrapperVersion);
             }
+
+            //
+            // Install the launcher if not already found.
+            //
+            File kobaltw = new File(KOBALTW);
+            File kobaltw_bat = new File(KOBALTW_BAT);
+
+            if (!kobaltw.exists()) {
+                generateKobaltW(kobaltw.toPath());
+            }
+
+            if (!kobaltw_bat.exists()) {
+                generateKobaltWBat(kobaltw_bat.toPath());
+            }
         }
 
         return kobaltJarFile;


### PR DESCRIPTION
So that `kobaltw` can be used as a symlink. eg:

```
ln -s /usr/local/share/kobalt/bin/kobaltw /usr/local/bin/
```
or even has a local installation:

```
ln -s ~/kobalt-1.0.20/bin/kobaltw ~/bin
```

No need to mess around with temporarily exporting paths, etc. I suspect `brew` does something similar.

With that in mind, the manual installation instructions could be changed to:

```
cd yourLocation
unzip kobalt-xxx.zip
cd kobalt-xxx
ln -s bin/kobaltw /usr/local/bin
```
or something of the sort.