### PR TITLE
Added test to check if kobaltw is executable (*nix only.)

### DIFF
--- a/src/test/kotlin/com/beust/kobalt/VerifyKobaltZipTest.kt
+++ b/src/test/kotlin/com/beust/kobalt/VerifyKobaltZipTest.kt
@@ -38,7 +38,7 @@ class VerifyKobaltZipTest : KobaltTest() {
                             throw KobaltException("kobaltw has wrong line endings")
                         }
                     }
-                    if (System.getProperty("os.name").contains("Windows")) {
+                    if (OperatingSystem.current().isWindows()) {
                         warn("Can't determine if kobaltw is executable under Windows")
                     } else if (!Files.isExecutable(Paths.get("dist/kobaltw"))) {
                         throw KobaltException("kobaltw has invalid permissions")

--- a/src/test/kotlin/com/beust/kobalt/VerifyKobaltZipTest.kt
+++ b/src/test/kotlin/com/beust/kobalt/VerifyKobaltZipTest.kt
@@ -1,9 +1,10 @@
 package com.beust.kobalt
 
-import com.beust.kobalt.misc.KFiles
-import com.beust.kobalt.misc.kobaltLog
+import com.beust.kobalt.misc.*
 import org.testng.annotations.Test
 import java.io.*
+import java.nio.file.Files
+import java.nio.file.Paths
 import java.util.*
 import java.util.jar.*
 
@@ -36,6 +37,11 @@ class VerifyKobaltZipTest : KobaltTest() {
                         if (it.compareTo(13) == 0) {
                             throw KobaltException("kobaltw has wrong line endings")
                         }
+                    }
+                    if (System.getProperty("os.name").contains("Windows")) {
+                        warn("Can't determine if kobaltw is executable under Windows")
+                    } else if (!Files.isExecutable(Paths.get("dist/kobaltw"))) {
+                        throw KobaltException("kobaltw has invalid permissions")
                     }
                     foundKobaltw = true
                 } else if (entry.name.endsWith(mainJarFilePath)) {


### PR DESCRIPTION
Fix for #401 

Unfortunately, there is no way determine if a file is executable on Windows, it assumes that any file your own is executable. I'm displaying a warning in that case (which might be overkill), but it will work on MacOS, Linux, etc.

I've looked in ways of determining if a `zipEntry` is executable, no luck there. I've even looked at `ACL` under Windows, no go either.