### PR TITLE
Made warn() work like error() with provided message

### DIFF
--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/KobaltLogger.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/misc/KobaltLogger.kt
@@ -1,6 +1,9 @@
 package com.beust.kobalt.misc
 
-import com.beust.kobalt.*
+import com.beust.kobalt.Args
+import com.beust.kobalt.AsciiArt
+import com.beust.kobalt.Constants
+import com.beust.kobalt.KobaltException
 import com.beust.kobalt.api.Kobalt
 import com.beust.kobalt.maven.aether.Exceptions
 import java.lang.Exception
@@ -75,7 +78,7 @@ class Logger(val dev: Boolean) {
 
     fun error(tag: String, message: CharSequence, e: Throwable? = null) {
         val docUrl = if (e is KobaltException && e.docUrl != null) e.docUrl else null
-        val text = if (! message.isBlank()) message
+        val text = if (message.isNotBlank()) message
             else if (e != null && (! e.message.isNullOrBlank())) e.message
             else { e?.toString() }
         val shortMessage = "***** E $text " + if (docUrl != null) " Documentation: $docUrl" else ""
@@ -88,7 +91,9 @@ class Logger(val dev: Boolean) {
     }
 
     fun warn(tag: String, message: CharSequence, e: Throwable? = null) {
-        val fullMessage = "***** WARNING " + (e?.message ?: message)
+        val fullMessage = "***** WARNING " + if (message.isNotBlank()) message
+            else if (e != null && (!e.message.isNullOrBlank())) e.message
+            else e?.toString()
         println(AsciiArt.Companion.warnColor(getPattern("W", fullMessage, fullMessage, tag)))
         if (KobaltLogger.LOG_LEVEL > 1 && e != null) {
             Exceptions.printStackTrace(e)


### PR DESCRIPTION
Fix for #420 `warn()` issue.

Notice that the implementation is identical to `error()` which did things _correctly_.