### PR TITLE
Removed sources directory from apt generated directory path

### DIFF
--- a/src/main/kotlin/com/beust/kobalt/plugin/apt/AptPlugin.kt
+++ b/src/main/kotlin/com/beust/kobalt/plugin/apt/AptPlugin.kt
@@ -243,9 +243,9 @@ class AptPlugin @Inject constructor(val dependencyManager: DependencyManager, va
         fun addFlags(outputDir: String) {
             aptDependencies[project.name]?.let {
                 result.add("-s")
-                generatedSources(project, context, outputDir).let { generatedSource ->
-                    File(generatedSource).mkdirs()
-                    result.add(generatedSource)
+                generatedDir(project, outputDir).let { generatedSource ->
+                    generatedSource.mkdirs()
+                    result.add(generatedSource.path)
                 }
             }
         }


### PR DESCRIPTION
As discussed, this reverts to the previous `apt` implementation behavior. It does not affect `kapt` at all, and passed all of my tests with `semver` and `version-processor`.

The reason the `sources` directory was added to path is because you used the same directory creation function (`generatedSources`) for both `kapt` and `apt`. While `kapt` needs a few directories, `apt` doesn't.

As before, generated code is placed in `generated/source/apt`, and no longer in `generated/source/apt/sources/`.


