### PR TITLE
Fixed finding tools.jar under Windows when JAVA_HOME is set to JRE.

### DIFF
--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/Jvm.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/Jvm.kt
@@ -67,7 +67,7 @@ open class Jvm constructor(
             return toolsJar
         }
         if (javaHome!!.name.equals("jre", true)) {
-            javaHome = javaHome!!.parentFile
+            _javaHome = javaHome!!.parentFile
             toolsJar = File(javaHome, "lib/tools.jar")
             if (toolsJar.exists()) {
                 return toolsJar
@@ -78,7 +78,7 @@ open class Jvm constructor(
             val version = SystemProperties.Companion.javaVersion
             if (javaHome!!.name.toRegex().matches("jre\\d+")
                     || javaHome!!.name == "jre$version") {
-                javaHome = File(javaHome!!.parentFile, "jdk$version")
+                _javaHome = File(javaHome!!.parentFile, "jdk$version")
                 toolsJar = File(javaHome, "lib/tools.jar")
                 if (toolsJar.exists()) {
                     return toolsJar


### PR DESCRIPTION
The problem was that getting `javaHome` always return the value of `_javaHome`, so trying to set it is useless:

```kotlin
    override var javaHome: File? = null
        get() = _javaHome!!
```

To test with the previous version, simply set your JAVA_HOME to a JRE instead of JDK location. Tools.jar will not be found. For example:

```
export JAVA_HOME="C:\Program Files\Java\jre1.8.0_151"
```
