### PR TITLE
Disable kotlin incremental compilation

### DIFF
--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/Args.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/Args.kt
@@ -86,8 +86,8 @@ class Args {
     @Parameter(names = arrayOf("--projectInfo"), description = "Display information about the current projects")
     var projectInfo: Boolean = false
 
-    @Parameter(names = arrayOf("--noIncrementalKotlin"), description = "Disable incremental Kotlin compilation")
-    var noIncrementalKotlin: Boolean = false
+    @Parameter(names = arrayOf("--incrementalKotlin"), description = "Disable incremental Kotlin compilation")
+    var incrementalKotlin: Boolean = false
 
     companion object {
         const val SEQUENTIAL = "--sequential"

--- a/src/main/kotlin/com/beust/kobalt/app/BuildFiles.kt
+++ b/src/main/kotlin/com/beust/kobalt/app/BuildFiles.kt
@@ -253,7 +253,7 @@ class BuildFiles @Inject constructor(val factory: BuildFileCompiler.IFactory,
 
 fun main(argv: Array<String>) {
     val args = Args().apply {
-        noIncrementalKotlin = true
+        incrementalKotlin = false
     }
     val context = KobaltContext(args)
     KobaltLogger.LOG_LEVEL = 3

--- a/src/main/kotlin/com/beust/kobalt/plugin/kotlin/KotlinCompiler.kt
+++ b/src/main/kotlin/com/beust/kobalt/plugin/kotlin/KotlinCompiler.kt
@@ -255,7 +255,7 @@ class KotlinCompiler @Inject constructor(
 //            // TODO: experimental should be removed as soon as it becomes standard
 //            System.setProperty("kotlin.incremental.compilation.experimental", "true")
 
-            return if (cliArgs.noIncrementalKotlin || Kobalt.context?.internalContext?.noIncrementalKotlin ?: false) {
+            return if (!cliArgs.incrementalKotlin || Kobalt.context?.internalContext?.noIncrementalKotlin == true) {
                 log(2, "  Kotlin incremental compilation is disabled")
                 val duration = benchmarkMillis {
                     compiler.exec(collector, Services.Builder().build(), args)

--- a/src/main/resources/kobalt.properties
+++ b/src/main/resources/kobalt.properties
@@ -1,1 +1,1 @@
-kobalt.version=1.0.115
+kobalt.version=1.0.116

--- a/src/test/kotlin/com/beust/kobalt/BaseTest.kt
+++ b/src/test/kotlin/com/beust/kobalt/BaseTest.kt
@@ -82,7 +82,7 @@ open class BaseTest(val compilerFactory: BuildFileCompiler.IFactory? = null) {
         args.apply {
             buildFile = actualBuildFile.absolutePath
             noIncremental = true
-            noIncrementalKotlin = true
+            incrementalKotlin = false
         }
         val jvmCompilerPlugin = Kobalt.findPlugin("JvmCompiler") as JvmCompilerPlugin
         val pluginInfo = PluginInfo(KobaltPluginXml(), null, null).apply {


### PR DESCRIPTION
due to changes in the Kotlin compiler, 1.0.115 will cause people trouble if they allow incremental compilation (which is on by default).