### PR TITLE
Improve external compiler invocation

### DIFF
--- a/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/KotlinJarFiles.kt
+++ b/modules/kobalt-plugin-api/src/main/kotlin/com/beust/kobalt/internal/KotlinJarFiles.kt
@@ -16,6 +16,5 @@ class KotlinJarFiles @Inject constructor(val dependencyManager: DependencyManage
     }
 
     val stdlib: File get() = getKotlinCompilerJar("stdlib")
-    val runtime: File get() = getKotlinCompilerJar("runtime")
     val compiler: File get() = getKotlinCompilerJar("compiler-embeddable")
 }

--- a/src/main/kotlin/com/beust/kobalt/app/kotlin/KotlinTemplateGenerator.kt
+++ b/src/main/kotlin/com/beust/kobalt/app/kotlin/KotlinTemplateGenerator.kt
@@ -8,8 +8,8 @@ class KotlinTemplateGenerator : LanguageTemplateGenerator() {
     override val defaultSourceDirectories = hashSetOf("src/main/kotlin")
     override val defaultTestDirectories = hashSetOf("src/test/kotlin")
     override val mainDependencies = arrayListOf(
-            Pom.Dependency("org.jetbrains.kotlin", "kotlin-runtime", null, Constants.KOTLIN_COMPILER_VERSION),
-            Pom.Dependency("org.jetbrains.kotlin", "kotlin-stdlib", null, Constants.KOTLIN_COMPILER_VERSION))
+            Pom.Dependency("org.jetbrains.kotlin", "kotlin-stdlib", null, Constants.KOTLIN_COMPILER_VERSION)
+    )
     override val testDependencies = arrayListOf<Pom.Dependency>()
     override val directive = "project"
     override val templateName = "kotlin"

--- a/src/main/kotlin/com/beust/kobalt/plugin/kotlin/KotlinPlugin.kt
+++ b/src/main/kotlin/com/beust/kobalt/plugin/kotlin/KotlinPlugin.kt
@@ -101,7 +101,7 @@ class KotlinPlugin @Inject constructor(val executors: KobaltExecutors, val depen
     override fun classpathEntriesFor(project: Project?, context: KobaltContext): List<IClasspathDependency> =
         if (project == null || accept(project)) {
             // All Kotlin projects automatically get the Kotlin runtime added to their class path
-            listOf(kotlinJarFiles.stdlib, kotlinJarFiles.runtime)
+            listOf(kotlinJarFiles.stdlib)
                     .map { FileDependency(it.absolutePath) }
         } else {
             emptyList()

--- a/src/main/kotlin/com/beust/kobalt/plugin/kotlin/KotlinPlugin.kt
+++ b/src/main/kotlin/com/beust/kobalt/plugin/kotlin/KotlinPlugin.kt
@@ -99,7 +99,8 @@ class KotlinPlugin @Inject constructor(val executors: KobaltExecutors, val depen
     // IClasspathContributor
 
     override fun classpathEntriesFor(project: Project?, context: KobaltContext): List<IClasspathDependency> =
-        if (project == null || accept(project)) {
+        if (project == null ||
+                context.pluginInfo.plugins.any { it is KotlinPlugin && it.settings.kobaltCompilerVersion == null }) {
             // All Kotlin projects automatically get the Kotlin runtime added to their class path
             listOf(kotlinJarFiles.stdlib)
                     .map { FileDependency(it.absolutePath) }

--- a/src/main/resources/kobalt.properties
+++ b/src/main/resources/kobalt.properties
@@ -1,1 +1,1 @@
-kobalt.version=1.0.120
+kobalt.version=1.0.121

--- a/src/main/resources/templates/idea/KotlinJavaRuntime.xml
+++ b/src/main/resources/templates/idea/KotlinJavaRuntime.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="KotlinJavaRuntime">
     <CLASSES>
-      <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-runtime.jar!/" />
+      <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-stdlib.jar!/" />
       <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-reflect.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-runtime-sources.jar!/" />
+      <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-stdlib-sources.jar!/" />
     </SOURCES>
   </library>
 </component>


### PR DESCRIPTION
- extend external compiler timeout to 2min, logs clear error when timeout happens
- don't add kotlin-runtime jar to classpath (does not exist in kotlin 1.3.10)
