### PR TITLE
fix test - bind new instance of executors for each test

### DIFF
--- a/src/main/kotlin/com/beust/kobalt/app/MainModule.kt
+++ b/src/main/kotlin/com/beust/kobalt/app/MainModule.kt
@@ -46,10 +46,8 @@ open class MainModule(val args: Args, val settings: KobaltSettings) : AbstractMo
 
 //        bind(javaClass<TaskManager>()).toProvider(javaClass<TaskManagerProvider>())
 //                .`in`(Scopes.SINGLETON)
-        bind(object: TypeLiteral<KobaltExecutors>() {}).toInstance(executors)
-        bind(object: TypeLiteral<ExecutorService>() {}).annotatedWith(DependencyExecutor::class.java)
-                .toInstance(executors.dependencyExecutor)
-        bind(Args::class.java).toProvider(Provider<Args> {
+      bindExecutors()
+      bind(Args::class.java).toProvider(Provider<Args> {
             args
         })
         bind(EventBus::class.java).toInstance(EventBus())
@@ -74,4 +72,10 @@ open class MainModule(val args: Args, val settings: KobaltSettings) : AbstractMo
 //            }
 //        })
     }
+
+  protected open fun bindExecutors() {
+    bind(object : TypeLiteral<KobaltExecutors>() {}).toInstance(executors)
+    bind(object : TypeLiteral<ExecutorService>() {}).annotatedWith(DependencyExecutor::class.java)
+      .toInstance(executors.dependencyExecutor)
+  }
 }

--- a/src/test/kotlin/com/beust/kobalt/TestModule.kt
+++ b/src/test/kotlin/com/beust/kobalt/TestModule.kt
@@ -12,6 +12,7 @@ import com.google.common.eventbus.EventBus
 import com.google.inject.Provider
 import com.google.inject.Scopes
 import java.io.File
+import java.util.concurrent.ExecutorService
 
 val LOCAL_CACHE = File(SystemProperties.homeDir + File.separatorChar + ".kobalt-test")
 
@@ -38,5 +39,10 @@ class TestModule : MainModule(Args(), TEST_KOBALT_SETTINGS) {
                 }
             }
         }).`in`(Scopes.SINGLETON)
+    }
+
+    override fun bindExecutors() {
+        // in tests do nothing to bind new executors for each tests
+        // this avoids tests submitting tasks after pool shutdown
     }
 }


### PR DESCRIPTION
when tests in KotlinCompilerVersionTest called separately they pass, but
together they fail with rejected execution exception. this happens
because each test call shutdown on the pool. The fix is to change test
to create new pool (instead of singleton pool).
Looking on production code it looks shutdown is called only once in the end.

This is the exception from test:
```
Task java.util.concurrent.FutureTask@52af14e7 rejected from com.beust.kobalt.misc.KobaltExecutor@26794546[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 1]
java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.FutureTask@52af14e7 rejected from com.beust.kobalt.misc.KobaltExecutor@26794546[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 1]
	at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2063)
	at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:830)
	at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1379)
	at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:134)
	at com.beust.kobalt.misc.GithubApi2.getLatestKobaltVersion(GithubApi2.kt:170)
	at com.beust.kobalt.Main.run(Main.kt:110)
	at com.beust.kobalt.Main$Companion.launchMain(Main.kt:67)
	at com.beust.kobalt.BaseTest.launchProject(BaseTest.kt:130)
	at com.beust.kobalt.internal.KotlinCompilerVersionTest.shouldFailWhenKotlinVersionDoesNotExist(KotlinCompilerVersionTest.kt:54)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:124)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:571)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:707)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:979)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:109)
	at org.testng.TestRunner.privateRun(TestRunner.java:648)
	at org.testng.TestRunner.run(TestRunner.java:505)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:455)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:450)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:415)
	at org.testng.SuiteRunner.run(SuiteRunner.java:364)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:84)
```